### PR TITLE
Add workflow validation test

### DIFF
--- a/.github/workflows/mirror-iRingo.yml
+++ b/.github/workflows/mirror-iRingo.yml
@@ -46,17 +46,38 @@ jobs:
           while IFS= read -r REPO; do
             echo "Processing repository: $REPO"
 
-            RELEASE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$REPO/releases/latest")
+            API_URL="https://api.github.com/repos/$REPO/releases/latest"
+            RELEASE=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" "$API_URL")
 
-            # Check if release data was retrieved
-            if [ -z "$RELEASE" ] || [ "$RELEASE" == "null" ] || [ "$(echo "$RELEASE" | jq -r '.message')" = "Not Found" ]; then
-              echo "Release not found for $REPO, skipping."
+            # Check if release data was retrieved successfully
+            if [ -z "$RELEASE" ] || [ "$RELEASE" = "null" ]; then
+              echo "No release response for $REPO, skipping."
+              continue
+            fi
+
+            ERROR_MESSAGE=$(echo "$RELEASE" | jq -r '.message // empty')
+            if [ "$ERROR_MESSAGE" = "Moved Permanently" ]; then
+              REDIRECT_URL=$(echo "$RELEASE" | jq -r '.url // empty')
+              if [ -n "$REDIRECT_URL" ]; then
+                echo "Following redirect for $REPO to $REDIRECT_URL"
+                RELEASE=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" "$REDIRECT_URL")
+                ERROR_MESSAGE=$(echo "$RELEASE" | jq -r '.message // empty')
+              fi
+            fi
+
+            if [ -n "$ERROR_MESSAGE" ]; then
+              echo "Failed to fetch release for $REPO: $ERROR_MESSAGE"
               continue
             fi
 
             # Log release information
             echo "Release data for $REPO:"
             echo "$RELEASE" | jq '.'
+
+            if ! echo "$RELEASE" | jq -e 'has("assets") and (.assets | type == "array") and (.assets | length > 0)' >/dev/null; then
+              echo "No assets found for $REPO."
+              continue
+            fi
 
             ASSETS=$(echo "$RELEASE" | jq -c '.assets[]')
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Mirrored",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"No test specified\" && exit 1"
+    "test": "./scripts/validate_workflow.rb"
   },
   "author": "Mirrored",
   "license": "MIT",

--- a/scripts/validate_workflow.rb
+++ b/scripts/validate_workflow.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'yaml'
+require 'json'
+require 'time'
+
+workflow_path = File.expand_path('../.github/workflows/mirror-iRingo.yml', __dir__)
+workflow = YAML.safe_load(File.read(workflow_path), aliases: true)
+
+raise 'Expected jobs.download_assets.steps to be an Array' unless workflow.dig('jobs', 'download_assets', 'steps').is_a?(Array)
+
+required_step_names = [
+  'Checkout main branch',
+  'Set repository list',
+  'Download and categorize release assets'
+]
+
+step_names = workflow.dig('jobs', 'download_assets', 'steps').map { |step| step['name'] }.compact
+
+missing_steps = required_step_names - step_names
+
+unless missing_steps.empty?
+  warn "Missing expected steps: #{missing_steps.join(', ')}"
+  exit 1
+end
+
+puts({
+  workflow: File.basename(workflow_path),
+  steps: step_names,
+  validated_at: Time.now.utc.iso8601
+}.to_json)


### PR DESCRIPTION
## Summary
- add a Ruby-based workflow validation script to ensure critical steps are present
- wire npm test to run the validation so the workflow can be sanity checked locally

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4d82aa5008328b5d16a5c55e4d6f2