### PR TITLE
Force TLS 1.2 for plugin list download

### DIFF
--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -46,24 +46,26 @@ jobs:
         run: |
           set -euo pipefail
 
-          candidate_urls=(
-            "https://hub.kelee.one/list.json"
-          )
+          url="https://hub.kelee.one/list.json"
+          echo "Downloading: $url"
 
-          browser_header="Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:122.0) Gecko/20100101 Firefox/122.0"
-
-          for url in "${candidate_urls[@]}"; do
-            echo "Trying: $url"
-            if curl -fLsS -H "User-Agent: $browser_header" "$url" -o plugin_data.json && [ -s plugin_data.json ]; then
-              echo "✓ Downloaded plugin catalog from $url"
-              break
-            fi
-          done
-
-          if [ ! -s plugin_data.json ]; then
-            echo "::error ::Failed to download plugin list from all known endpoints"
+          # hub.kelee.one blocks the default curl user agent and TLS 1.3 handshakes
+          # with a Cloudflare challenge. Forcing TLS 1.2 and sending a browser-like
+          # user agent matches what succeeds locally.
+          if ! curl -fLsS \
+            --tlsv1.2 \
+            -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36" \
+            "$url" -o plugin_data.json; then
+            echo "::error ::Failed to download plugin list from $url"
             exit 1
           fi
+
+          if [ ! -s plugin_data.json ]; then
+            echo "::error ::Plugin list download produced an empty file"
+            exit 1
+          fi
+
+          echo "✓ Downloaded plugin catalog from $url"
 
       - name: Extract plugin source URLs
         run: |


### PR DESCRIPTION
## Summary
- remove the fallback URL loop and always pull the catalog from hub.kelee.one
- force curl to use TLS 1.2 with a browser-like user agent so Cloudflare stops returning 403
- add an explicit empty-file check for the downloaded catalog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e51d05c20c8328a759f15682b94481